### PR TITLE
Use suspend-compatible map lambda in ProductDao

### DIFF
--- a/app/src/main/java/com/manele/spesify/core/data/dao/ProductDao.kt
+++ b/app/src/main/java/com/manele/spesify/core/data/dao/ProductDao.kt
@@ -1,0 +1,12 @@
+package com.manele.spesify.core.data.dao
+
+import com.manele.spesify.core.domain.Product
+import com.manele.spesify.core.domain.ShoppingList
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class ProductDao(private val shoppingLists: Flow<ShoppingList>) {
+
+    fun observeProducts(): Flow<Map<Product, Int>> =
+        shoppingLists.map { it.products }
+}


### PR DESCRIPTION
## Summary
- add a ProductDao implementation that maps shopping list flows to product maps using a suspend-compatible lambda

## Testing
- ./gradlew build *(fails: gradlew script not present in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d68d99c2a48330937aa8e2d15c6090