### PR TITLE
Add Firebase Firestore dependencies to app module

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,4 @@
+dependencies {
+    implementation(platform("com.google.firebase:firebase-bom:33.5.1"))
+    implementation("com.google.firebase:firebase-firestore-ktx")
+}


### PR DESCRIPTION
## Summary
- add the Firebase platform BOM to the app module dependencies
- include the Firestore KTX client so DAOs can reference FirebaseFirestore

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d68da139a08330890733e5543e5a28